### PR TITLE
Statuses

### DIFF
--- a/gen_1_moves.json
+++ b/gen_1_moves.json
@@ -1,166 +1,1894 @@
-{"name": "absorb", "type": "grass", "category": "special", "power": 20, "accuracy": 1.0, "pp": 20, "effects": ["Absorb deals damage and the user will recover 50% of the HP drained."]}
-{"name": "acid", "type": "poison", "category": "physical", "power": 40, "accuracy": 1.0, "pp": 30, "effect": {"chance": 0.1, "stat": "defense", "stages": -1}}
-{"name": "acid armor", "type": "poison", "category": "status", "power": null, "accuracy": null, "pp": 40, "effect": {"stat": "defense", "stages": 2}}
-{"name": "agility", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 30, "effect": {"stat": "speed", "stages": 2}}
-{"name": "amnesia", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 20, "effect": {"stat": "special", "stages": 2}}
-{"name": "aurora beam", "type": "ice", "category": "special", "power": 65, "accuracy": 1.0, "pp": 20, "effect": {"chance": 0.1, "stat": "attack", "stages": -1}}
-{"name": "barrage", "type": "normal", "category": "physical", "power": 15, "accuracy": 0.85, "pp": 20, "changes": ["In Generations 1-3, Barrage ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "barrier", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 30, "effect": {"stat": "defense", "stages": 2}}
-{"name": "bide", "type": "normal", "category": "physical", "power": null, "accuracy": null, "pp": 10, "effects": ["The user of Bide stores energy for 2 turns. At the end of the second turn the Pokémon unleashes energy, dealing twice the HP damage it received.", "Bide deals fixed, typeless damage, so will hit Ghost-type Pokémon. It also ignores changes to the Accuracy and Evasion stats and can hit Pokémon in the invulnerable stage of Bounce, Dig, Dive, Fly, Shadow Force or Sky Drop."], "changes": ["In Generations 1-3, Bide is not an increased priority move. It also stores energy for 2-3 turns."]}
-{"name": "bind", "type": "normal", "category": "physical", "power": 15, "accuracy": 0.85, "pp": 20, "effects": ["Bind inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns."], "changes": ["In Generations 1-4, Bind has 75% accuracy. Its after-effects last for 2-5 turns instead of 4-5.", "In Generation 1, Bind simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."]}
-{"name": "bite", "type": "normal", "category": "physical", "power": 60, "accuracy": 1.0, "pp": 25, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "blizzard", "type": "ice", "category": "special", "power": 120, "accuracy": 0.9, "pp": 5, "effect": {"chance": 0.1, "statusCondition": "freeze"}}
-{"name": "body slam", "type": "normal", "category": "physical", "power": 85, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.3, "statusCondition": "paralysis"}}
-{"name": "bone club", "type": "ground", "category": "physical", "power": 65, "accuracy": 0.85, "pp": 20, "effect": {"chance": 0.1, "statusCondition": "flinch"}}
-{"name": "bonemerang", "type": "ground", "category": "physical", "power": 50, "accuracy": 0.9, "pp": 10, "effects": ["Bonemerang deals damage and will strike twice (with 50 base power each time).\nEach strike of Bonemerang is treated like a separate attack:"], "changes": ["In Generations 1-3, Bonemerang ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "bubble", "type": "water", "category": "special", "power": 20, "accuracy": 1.0, "pp": 30, "effect": {"chance": 0.1, "stat": "speed", "stages": -1}}
-{"name": "bubble beam", "type": "water", "category": "special", "power": 65, "accuracy": 1.0, "pp": 20, "effect": {"chance": 0.1, "stat": "speed", "stages": -1}}
-{"name": "clamp", "type": "water", "category": "physical", "power": 35, "accuracy": 0.85, "pp": 10, "effects": ["Clamp inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."], "changes": ["In Generations 1-4, Clamp has 75% accuracy. Its after-effects last for 2-5 turns instead of 4-5.", "In Generation 1, Clamp simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."]}
-{"name": "comet punch", "type": "normal", "category": "physical", "power": 18, "accuracy": 0.85, "pp": 15, "changes": ["In Generations 1-3, Comet Punch ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "confuse ray", "type": "ghost", "category": "status", "power": null, "accuracy": 1.0, "pp": 10, "effect": {"statusCondition": "confused"}}
-{"name": "confusion", "type": "psychic", "category": "special", "power": 50, "accuracy": 1.0, "pp": 25, "effect": {"chance": 0.1, "statusCondition": "confused"}}
-{"name": "constrict", "type": "normal", "category": "physical", "power": 10, "accuracy": 1.0, "pp": 35, "effect": {"chance": 0.1, "stat": "speed", "stages": -1}}
-{"name": "conversion", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 30, "changes": ["In Generation 1, Conversion changes the user's type to the target Pokémon's type."]}
-{"name": "counter", "type": "fighting", "category": "physical", "power": null, "accuracy": 1.0, "pp": 20, "priority": -1, "effects": ["When hit by a Physical Attack, user strikes back with 2x power."]}
-{"name": "crabhammer", "type": "water", "category": "physical", "power": 90, "accuracy": 0.85, "pp": 10, "highCriticalHitRatio": true}
-{"name": "cut", "type": "normal", "category": "physical", "power": 50, "accuracy": 0.95, "pp": 30}
-{"name": "defense curl", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 40, "effect": {"stat": "defense", "stages": 1}}
-{"name": "dig", "type": "ground", "category": "physical", "power": 60, "accuracy": 1.0, "pp": 10, "effects": ["The user of Dig will burrow its way underground on the first turn, disappearing from view and becoming invulnerable to most attacks. On the second turn, Dig deals damage."]}
-{"name": "disable", "type": "normal", "category": "status", "power": null, "accuracy": 0.55, "pp": 20, "effects": ["Disable causes the previous move the target used to be disabled for 1-8 turns, which prevents the move's use."]}
-{"name": "dizzy punch", "type": "normal", "category": "physical", "power": 70, "accuracy": 1.0, "pp": 10}
-{"name": "double kick", "type": "fighting", "category": "physical", "power": 30, "accuracy": 1.0, "pp": 30, "effects": ["Double Kick deals damage and will strike twice (with 30 base power each time).\nEach strike of Double Kick is treated like a separate attack:"], "changes": ["In Generations 1-3, Double Kick ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "double slap", "type": "normal", "category": "physical", "power": 15, "accuracy": 0.85, "pp": 10, "effects": [], "changes": ["In Generations 1-3, Double Slap ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest.", "In Generations 1-5, this move's name was formatted as DoubleSlap."]}
-{"name": "double team", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 15, "effect": {"stat": "evasiveness", "stages": 1}}
-{"name": "double-edge", "type": "normal", "category": "physical", "power": 100, "accuracy": 1.0, "pp": 15, "effects": ["Double-Edge deals damage, but the user receives 1⁄3 of the damage it inflicted in recoil. In other words, if the attack does 90 HP damage to the opponent, the user will lose 30 HP."], "changes": ["In Generations 1-2, the recoil is 1⁄4 of the damage inflicted."]}
-{"name": "dragon rage", "type": "dragon", "category": "special", "power": null, "accuracy": 1.0, "pp": 10, "effects": ["Dragon Rage always deals 40 HP damage to the target, regardless of typing. It has no additional effect."]}
-{"name": "dream eater", "type": "psychic", "category": "special", "power": 100, "accuracy": 1.0, "pp": 15, "effects": ["Dream Eater deals damage only on sleeping foes and the user will recover 50% of the HP drained."]}
-{"name": "drill peck", "type": "flying", "category": "physical", "power": 80, "accuracy": 1.0, "pp": 20}
-{"name": "earthquake", "type": "ground", "category": "physical", "power": 100, "accuracy": 1.0, "pp": 10}
-{"name": "egg bomb", "type": "normal", "category": "physical", "power": 100, "accuracy": 0.75, "pp": 10}
-{"name": "ember", "type": "fire", "category": "special", "power": 40, "accuracy": 1.0, "pp": 25, "effect": {"chance": 0.1, "statusCondition": "burn"}}
-{"name": "explosion", "type": "normal", "category": "physical", "power": 170, "accuracy": 1.0, "pp": 5, "effects": ["Explosion deals high damage, but causes the user to faint."], "changes": ["In Generations 1-4, the opponent's defense stat is temporarily halved when calculating the damage. This gives Explosion an effective power of 340."]}
-{"name": "fire blast", "type": "fire", "category": "special", "power": 120, "accuracy": 0.85, "pp": 5, "effect": {"chance": 0.1, "statusCondition": "burn"}}
-{"name": "fire punch", "type": "fire", "category": "physical", "power": 75, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "burn"}}
-{"name": "fire spin", "type": "fire", "category": "special", "power": 35, "accuracy": 0.85, "pp": 15, "effects": ["Fire Spin inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."], "changes": ["In Generations 1-4, Fire Spin has a base power of 15 and 70% accuracy. Its after-effects last for 2-5 turns instead of 4-5.", "In Generation 1, Fire Spin simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."]}
-{"name": "fissure", "type": "ground", "category": "physical", "power": null, "accuracy": null, "pp": 5, "effects": ["If it hits, Fissure is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.", "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"], "changes": ["In Generation 1, Fissure has 30% accuracy and can hit Pokémon of any level, but does not affect Pokémon faster than the user."]}
-{"name": "flamethrower", "type": "fire", "category": "special", "power": 95, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "burn"}}
-{"name": "flash", "type": "normal", "category": "status", "power": null, "accuracy": 0.7, "pp": 20, "effect": {"stat": "accuracy", "stages": -1}}
-{"name": "fly", "type": "flying", "category": "physical", "power": 70, "accuracy": 0.95, "pp": 15, "effects": ["The user of Fly will fly up high on the first turn, disappearing from view and becoming invulnerable to most attacks. On the second turn, Fly deals damage.", "While in the air, the Pokémon can only be hit by the moves Gust, Twister, Thunder, Sky Uppercut and Smack Down, with Gust and Twister dealing twice normal damage. Moves from No Guard Pokémon, or any move following an identify move can also hit for regular power."]}
-{"name": "focus energy", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 30, "highCriticalHitRatio": true}
-{"name": "fury attack", "type": "normal", "category": "physical", "power": 15, "accuracy": 0.85, "pp": 20, "effects": [], "changes": ["In Generations 1-3, Fury Attack ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "fury swipes", "type": "normal", "category": "physical", "power": 18, "accuracy": 0.8, "pp": 15, "effects": [], "changes": ["In Generations 1-3, Fury Swipes ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "glare", "type": "normal", "category": "status", "power": null, "accuracy": 0.75, "pp": 30, "effect": {"statusCondition": "paralysis"}}
-{"name": "growl", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 40, "effect": {"stat": "attack", "stages": -1}}
-{"name": "growth", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 40, "effect": {"stat": "special", "stages": 1}}
-{"name": "guillotine", "type": "normal", "category": "physical", "power": null, "accuracy": null, "pp": 5, "effects": ["If it hits, Guillotine is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.", "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"], "changes": ["In Generation 1, Guillotine has 30% accuracy, but does not affect opponents faster than the user."]}
-{"name": "gust", "type": "normal", "category": "special", "power": 40, "accuracy": 1.0, "pp": 35}
-{"name": "harden", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 30, "effect": {"stat": "defense", "stages": 1}}
-{"name": "haze", "type": "ice", "category": "status", "power": null, "accuracy": null, "pp": 30, "effects": ["Resets all stat changes."]}
-{"name": "headbutt", "type": "normal", "category": "physical", "power": 70, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "high jump kick", "type": "fighting", "category": "physical", "power": 85, "accuracy": 0.9, "pp": 20, "effects": ["High Jump Kick deals damage, however, if it misses the user keeps going and crashes, losing 1⁄2 of its maximum HP. High Jump Kick cannot be used if Gravity is in effect."], "changes": ["In Generation 1, the crash damage is always 1 HP."]}
-{"name": "horn attack", "type": "normal", "category": "physical", "power": 65, "accuracy": 1.0, "pp": 25}
-{"name": "horn drill", "type": "normal", "category": "physical", "power": null, "accuracy": null, "pp": 5, "effects": ["If it hits, Horn Drill is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.", "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"], "changes": ["In Generation 1, Horn Drill has 30% accuracy, but does not affect opponents faster than the user."]}
-{"name": "hydro pump", "type": "water", "category": "special", "power": 120, "accuracy": 0.8, "pp": 5}
-{"name": "hyper beam", "type": "normal", "category": "special", "power": 150, "accuracy": 0.9, "pp": 5, "effects": ["Hyper Beam deals damage, but the user must recharge on the next turn (bringing its effective power down to 75 per turn)."], "changes": ["In Generation 1, if Hyper Beam KOs a Pokemon, it does not need to recharge."]}
-{"name": "hyper fang", "type": "normal", "category": "physical", "power": 80, "accuracy": 0.9, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "flinch"}}
-{"name": "hypnosis", "type": "psychic", "category": "status", "power": null, "accuracy": 0.6, "pp": 20, "effect": {"statusCondition": "sleep"}}
-{"name": "ice beam", "type": "ice", "category": "special", "power": 95, "accuracy": 1.0, "pp": 10, "effect": {"chance": 0.1, "statusCondition": "freeze"}}
-{"name": "ice punch", "type": "ice", "category": "physical", "power": 75, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "freeze"}}
-{"name": "jump kick", "type": "fighting", "category": "physical", "power": 70, "accuracy": 0.95, "pp": 25, "effects": ["Jump Kick deals damage, however, if it misses the user keeps going and crashes, losing 1⁄2 of its maximum HP. Jump Kick cannot be used if Gravity is in effect."], "changes": ["In Generation 1, the crash damage is always 1 HP. From Generation 2 to Generation 4, the crash damage is 1⁄8 of the damage the attack would have inflicted (which could be all of the user's own HP)."]}
-{"name": "karate chop", "type": "normal", "category": "physical", "power": 50, "accuracy": 1.0, "pp": 25, "highCriticalHitRatio": true}
-{"name": "kinesis", "type": "psychic", "category": "status", "power": null, "accuracy": 0.8, "pp": 15, "effect": {"stat": "accuracy", "stages": -1}}
-{"name": "leech life", "type": "bug", "category": "physical", "power": 20, "accuracy": 1.0, "pp": 15, "effects": ["Leech Life deals damage and the user will recover 50% of the HP drained."]}
-{"name": "leech seed", "type": "grass", "category": "status", "power": null, "accuracy": 0.9, "pp": 10, "effects": ["Leech Seed plants a seed on the target that drains 1⁄8 of its maximum HP at the end of each turn and restores it to the user, or any Pokemon that takes its place. It does not work on Grass-type Pokemon; it does technically work against Pokemon with the Magic Guard ability, but no HP will be sapped."], "changes": ["In Generation 1, Leech Seed saps 1⁄16 of the target's HP. If the target is also badly poisoned, the damage increases by 1⁄16 each turn, in the same way as bad poison (and in addition to poison damage).", "In Generation 1 and Generation 2 only, Haze will also clear the effects of Leech Seed."]}
-{"name": "leer", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 30, "effect": {"stat": "defense", "stages": -1}}
-{"name": "lick", "type": "ghost", "category": "physical", "power": 20, "accuracy": 1.0, "pp": 30, "effect": {"chance": 0.3, "statusCondition": "paralysis"}}
-{"name": "light screen", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 30, "effects": ["Light Screen reduces damage from Special attacks by 50%, for 5 turns. Its effects apply to all Pokémon on the user's side of the field."]}
-{"name": "lovely kiss", "type": "normal", "category": "status", "power": null, "accuracy": 0.75, "pp": 10, "effect": {"statusCondition": "sleep"}}
-{"name": "low kick", "type": "fighting", "category": "physical", "power": 50, "accuracy": 0.9, "pp": 20, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "meditate", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 40, "effect": {"stat": "attack", "stages": 1}}
-{"name": "mega drain", "type": "grass", "category": "special", "power": 40, "accuracy": 1.0, "pp": 10, "effects": ["Mega Drain deals damage and the user will recover 50% of the HP drained.", "If the user is holding a Big Root, the move instead recovers 65% of the damage dealt (30% more than normal). If used on a Pokemon with the ability Liquid Ooze, the user instead loses the HP it would have otherwise gained."]}
-{"name": "mega kick", "type": "normal", "category": "physical", "power": 120, "accuracy": 0.75, "pp": 5}
-{"name": "mega punch", "type": "normal", "category": "physical", "power": 80, "accuracy": 0.85, "pp": 20}
-{"name": "metronome", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["User performs any move in the game at random."]}
-{"name": "mimic", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["Mimic copies the last move used by the target (replacing Mimic). The copied move always has 5 PP. The effect only lasts while the user is in battle: if the user switches out or when the battle ends, the move becomes Mimic again.", "Mimic cannot copy Chatter, Metronome, Sketch or Struggle."], "changes": ["In Generation 1, Mimic allows the user to choose any of the opponent's moves to copy."]}
-{"name": "minimize", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 20, "effect": {"stat": "evasiveness", "stages": 1}}
-{"name": "mirror move", "type": "flying", "category": "status", "power": null, "accuracy": null, "pp": 20, "effects": ["User performs the opponent's last move."]}
-{"name": "mist", "type": "ice", "category": "status", "power": null, "accuracy": null, "pp": 30, "effects": ["User's stats cannot be changed for a period of time."]}
-{"name": "night shade", "type": "ghost", "category": "special", "power": null, "accuracy": 1.0, "pp": 15, "effects": ["The damage of Night Shade is equal to the user's level. So at level 100 the Pokémon will inflict 100 HP damage."], "changes": ["In Generation 1, Night Shade also hits Normal- and Psychic-type Pokémon despite their immunity to Ghost-type attacks."]}
-{"name": "pay day", "type": "normal", "category": "physical", "power": 40, "accuracy": 1.0, "pp": 20}
-{"name": "peck", "type": "flying", "category": "physical", "power": 35, "accuracy": 1.0, "pp": 35}
-{"name": "petal dance", "type": "grass", "category": "special", "power": 120, "accuracy": 1.0, "pp": 10, "effects": ["The user of Petal Dance attacks for 2-3 turns, during which it cannot switch out, and then becomes confused. Confused Pokémon have a 50% chance of hurting themselves each turn, for 1-4 turns. The damage received is as if the Pokémon attacks itself with a typeless 40 base power Physical attack.", "If Petal Dance is disrupted (e.g. if the move misses or the user cannot attack due to paralysis) then it will stop and not cause confusion.", "Pokémon with the ability Own Tempo or those behind a Substitute cannot be confused."], "changes": ["In Generations 1-3 Petal Dance has a base power of 70. In Generation 4 its base power is 90.", "In Generations 1-4, Petal Dance has 20 PP. Furthermore, sleep, freezing and flinching will pause but not disrupt Petal Dance.", "In Generation 1, Petal Dance lasts for 3-4 turns."]}
-{"name": "pin missile", "type": "bug", "category": "physical", "power": 14, "accuracy": 0.85, "pp": 20, "changes": ["In Generations 1-3, Pin Missile ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "poison gas", "type": "poison", "category": "status", "power": null, "accuracy": 0.55, "pp": 40, "effect": {"statusCondition": "poison"}}
-{"name": "poison powder", "type": "poison", "category": "status", "power": null, "accuracy": 0.75, "pp": 35, "effect": {"statusCondition": "poison"}}
-{"name": "poison sting", "type": "poison", "category": "physical", "power": 15, "accuracy": 1.0, "pp": 35, "effect": {"chance": 0.3, "statusCondition": "poison"}}
-{"name": "pound", "type": "normal", "category": "physical", "power": 40, "accuracy": 1.0, "pp": 35}
-{"name": "psybeam", "type": "psychic", "category": "special", "power": 65, "accuracy": 1.0, "pp": 20, "effect": {"chance": 0.1, "statusCondition": "confused"}}
-{"name": "psychic", "type": "psychic", "category": "special", "power": 90, "accuracy": 1.0, "pp": 10, "effect": {"chance": 0.3, "stat": "special", "stages": -1}}
-{"name": "psywave", "type": "psychic", "category": "special", "power": null, "accuracy": 0.8, "pp": 15, "effects": ["Psywave inflicts a random amount of HP damage, varying between 50% and 150% of the user's level. In other words, at level 100 the damage will be 50-150 HP.", "The damage is typeless (not affected by type advantages/disadvantages) but it still does not affect Dark type Pokemon."]}
-{"name": "quick attack", "type": "normal", "category": "physical", "power": 40, "accuracy": 1.0, "pp": 30, "priority": 1}
-{"name": "rage", "type": "normal", "category": "physical", "power": 20, "accuracy": 1.0, "pp": 20, "effects": ["Rage deals damage, and if the user is hit by a direct attack - any time after Rage is first used but before a different move is used - the user's Attack is raised by one stage. The game will state the Pokemon's rage is building rather than explicitly assert the stat increase. Stats can be raised to a maximum of +6 stages each.", "The Attack increases will continue as long as Rage is the last move used, even if it misses, the user is incapacitated (paralyzed, sleeping, etc) or the player uses an item. The Attack increase activates for every blow of multi-hit moves such as DoubleSlap or Fury Swipes.", "As an example, if a Pokemon uses Rage then the opponent hits the user in the same turn, the user's Attack increases. If the user moves last it will not increase that turn, but will in the next turn if the opponent hits the user again."], "changes": ["In Generation 1, after Rage is selected it will continue to be used until the end of the battle or the user faints.", "In Generations 2-3, if the user is slower than the opponent, the Attack rise only occurs if Rage is selected in that turn - if a different move is selected (or an item used) and the Pokemon is hit before it uses the new move, its Attack does not increase."]}
-{"name": "razor leaf", "type": "grass", "category": "physical", "power": 55, "accuracy": 0.95, "pp": 25, "highCriticalHitRatio": true}
-{"name": "razor wind", "type": "normal", "category": "special", "power": 80, "accuracy": 0.75, "pp": 10, "effects": ["The user of Razor Wind will whip up a whirlwind on the first turn. On the second turn, Razor Wind deals damage."]}
-{"name": "recover", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 20, "effects": ["Recover restores up to 50% of the user's maximum HP."]}
-{"name": "reflect", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 20, "effects": ["Reflect reduces damage from Physical attacks by 50%, for 5 turns. Its effects apply to all Pokémon on the user's side of the field."]}
-{"name": "rest", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["User sleeps for 2 turns, but user is fully healed."]}
-{"name": "roar", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 20}
-{"name": "rock slide", "type": "rock", "category": "physical", "power": 75, "accuracy": 0.9, "pp": 10, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "rock throw", "type": "rock", "category": "physical", "power": 50, "accuracy": 0.65, "pp": 15}
-{"name": "rolling kick", "type": "fighting", "category": "physical", "power": 60, "accuracy": 0.85, "pp": 15, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "sand attack", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 15, "effect": {"stat": "accuracy", "stages": -1}}
-{"name": "scratch", "type": "normal", "category": "physical", "power": 40, "accuracy": 1.0, "pp": 35}
-{"name": "screech", "type": "normal", "category": "status", "power": null, "accuracy": 0.85, "pp": 40, "effect": {"stat": "defense", "stages": -2}}
-{"name": "seismic toss", "type": "fighting", "category": "physical", "power": null, "accuracy": 1.0, "pp": 20, "effects": ["The damage of Seismic Toss is equal to the user's level. So at level 100 the Pokémon will inflict 100 HP damage."], "changes": ["In Generation 1 Seismic Toss can hit Ghost-type Pokémon despite their immunity to Fighting-type attacks."]}
-{"name": "self-destruct", "type": "normal", "category": "physical", "power": 200, "accuracy": 1.0, "pp": 5, "effects": ["Self-Destruct deals high damage, but causes the user to faint."]}
-{"name": "sharpen", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 30, "effect": {"stat": "attack", "stages": 1}}
-{"name": "sing", "type": "normal", "category": "status", "power": null, "accuracy": 0.55, "pp": 15, "effect": {"statusCondition": "sleep"}}
-{"name": "skull bash", "type": "normal", "category": "physical", "power": 100, "accuracy": 1.0, "pp": 15, "effects": ["The user of Skull Bash will tuck in its head on the first turn and raise its Defense by one stage. On the second turn, Skull Bash deals damage."], "changes": ["In Generation 1, Skull Bash does not raise the user's Defense."]}
-{"name": "sky attack", "type": "flying", "category": "physical", "power": 140, "accuracy": 0.9, "pp": 5, "effects": ["The user of Sky Attack will become cloaked in a harsh light on the first turn. On the second turn, Sky Attack deals damage."]}
-{"name": "slam", "type": "normal", "category": "physical", "power": 80, "accuracy": 0.75, "pp": 20}
-{"name": "slash", "type": "normal", "category": "physical", "power": 70, "accuracy": 1.0, "pp": 20, "highCriticalHitRatio": true}
-{"name": "sleep powder", "type": "grass", "category": "status", "power": null, "accuracy": 0.75, "pp": 15, "effect": {"statusCondition": "sleep"}}
-{"name": "sludge", "type": "poison", "category": "special", "power": 65, "accuracy": 1.0, "pp": 20, "effect": {"chance": 0.3, "statusCondition": "poison"}}
-{"name": "smog", "type": "poison", "category": "special", "power": 20, "accuracy": 0.7, "pp": 20, "effect": {"chance": 0.4, "statusCondition": "poison"}}
-{"name": "smokescreen", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 20, "effect": {"stat": "accuracy", "stages": -1}}
-{"name": "soft-boiled", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["Soft-Boiled recovers up to 50% of the user's maximum HP."]}
-{"name": "solar beam", "type": "grass", "category": "special", "power": 120, "accuracy": 1.0, "pp": 10, "effects": ["The user of Solar Beam will absorb light on the first turn. On the second turn, Solar Beam deals damage."]}
-{"name": "sonic boom", "type": "normal", "category": "special", "power": null, "accuracy": 0.9, "pp": 20, "effects": ["Sonic Boom always deals 20 HP damage to the target, regardless of typing (although Ghost type Pokémon are still immune). It has no additional effect."], "changes": ["In Generation 1, Sonic Boom hits Ghost types regardless of their immunity to Normal type moves."]}
-{"name": "spike cannon", "type": "normal", "category": "physical", "power": 20, "accuracy": 1.0, "pp": 15, "effects": [], "changes": ["In Generations 1-3, Spike Cannon ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "splash", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 40}
-{"name": "spore", "type": "grass", "category": "status", "power": null, "accuracy": 1.0, "pp": 15, "effect": {"statusCondition": "sleep"}}
-{"name": "stomp", "type": "normal", "category": "physical", "power": 65, "accuracy": 1.0, "pp": 20, "effect": {"chance": 0.3, "statusCondition": "flinch"}}
-{"name": "strength", "type": "normal", "category": "physical", "power": 80, "accuracy": 1.0, "pp": 15}
-{"name": "string shot", "type": "bug", "category": "status", "power": null, "accuracy": 0.95, "pp": 40, "effect": {"stat": "speed", "stages": -1}}
-{"name": "struggle", "type": "normal", "category": "physical", "power": 50, "accuracy": 1.0, "pp": null, "effects": ["Only usable when all PP are gone. Hurts the user."]}
-{"name": "stun spore", "type": "grass", "category": "status", "power": null, "accuracy": 0.75, "pp": 30, "effect": {"statusCondition": "paralysis"}}
-{"name": "submission", "type": "fighting", "category": "physical", "power": 80, "accuracy": 0.8, "pp": 25, "effects": ["Submission deals damage, but the user receives 1⁄4 of the damage it inflicts in recoil. In other words, if the attack does 100 HP damage to the opponent, the user will lose 25 HP."]}
-{"name": "substitute", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["Uses HP to creates a decoy that takes hits."]}
-{"name": "super fang", "type": "normal", "category": "physical", "power": null, "accuracy": 0.9, "pp": 10, "effects": ["Always takes off half of the opponent's HP."]}
-{"name": "supersonic", "type": "normal", "category": "status", "power": null, "accuracy": 0.55, "pp": 20, "effect": {"statusCondition": "confused"}}
-{"name": "surf", "type": "water", "category": "special", "power": 95, "accuracy": 1.0, "pp": 15}
-{"name": "swift", "type": "normal", "category": "special", "power": 60, "accuracy": null, "pp": 20, "changes": ["In Generation 1, Swift can hit Pokémon during the invulnerable stage of Dig and Fly."]}
-{"name": "swords dance", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 30, "effect": {"stat": "attack", "stages": 2}}
-{"name": "tackle", "type": "normal", "category": "physical", "power": 35, "accuracy": 0.95, "pp": 35}
-{"name": "tail whip", "type": "normal", "category": "status", "power": null, "accuracy": 1.0, "pp": 30, "effect": {"stat": "defense", "stages": -1}}
-{"name": "take down", "type": "normal", "category": "physical", "power": 90, "accuracy": 0.85, "pp": 20, "effects": ["Take Down deals damage, but the user receives 1⁄4 of the damage it inflicted in recoil. In other words, if the attack does 100 HP damage to the opponent, the user will lose 25 HP."]}
-{"name": "teleport", "type": "psychic", "category": "status", "power": null, "accuracy": null, "pp": 20}
-{"name": "thrash", "type": "normal", "category": "physical", "power": 120, "accuracy": 1.0, "pp": 10, "effects": ["The user of Thrash attacks for 2-3 turns, during which it cannot switch out, and then becomes confused. Confused Pokémon have a 50% chance of hurting themselves each turn, for 1-4 turns. The damage received is as if the Pokémon attacks itself with a typeless 40 base power Physical attack.", "If Thrash is disrupted (e.g. if the move misses or the user cannot attack due to paralysis) then it will stop and not cause confusion.", "Pokémon with the ability Own Tempo or those behind a Substitute cannot be confused."], "changes": ["In Generations 1-4, Thrash has 20 PP and a base power of 90. Furthermore, sleep, freezing and flinching will pause but not disrupt Thrash.", "In Generation 1, Thrash lasts for 3-4 turns."]}
-{"name": "thunder", "type": "electric", "category": "special", "power": 120, "accuracy": 0.7, "pp": 10, "effect": {"chance": 0.1, "statusCondition": "paralysis"}}
-{"name": "thunder punch", "type": "electric", "category": "physical", "power": 75, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "paralysis"}}
-{"name": "thunder shock", "type": "electric", "category": "special", "power": 40, "accuracy": 1.0, "pp": 30, "effect": {"chance": 0.1, "statusCondition": "paralysis"}}
-{"name": "thunder wave", "type": "electric", "category": "status", "power": null, "accuracy": 1.0, "pp": 20, "effect": {"statusCondition": "paralysis"}}
-{"name": "thunderbolt", "type": "electric", "category": "special", "power": 95, "accuracy": 1.0, "pp": 15, "effect": {"chance": 0.1, "statusCondition": "paralysis"}}
-{"name": "toxic", "type": "poison", "category": "status", "power": null, "accuracy": 0.85, "pp": 10, "changes": ["In Generation 1, Toxic also increases the damage taken by Leech Seed."], "effect": {"statusCondition": "badly poison"}}
-{"name": "transform", "type": "normal", "category": "status", "power": null, "accuracy": null, "pp": 10, "effects": ["User takes on the form and attacks of the opponent."]}
-{"name": "tri attack", "type": "normal", "category": "special", "power": 80, "accuracy": 1.0, "pp": 10}
-{"name": "twineedle", "type": "bug", "category": "physical", "power": 25, "accuracy": 1.0, "pp": 20, "effects": ["Twineedle deals damage and will strike twice (with 25 base power each time). It has a 20% chance of poisoning the target. Poison or Steel type Pokémon, those with the ability Immunity or those behind a Substitute cannot be poisoned.\nEach strike of Twineedle is treated like a separate attack:"], "changes": ["In Generations 1-2, Twineedle can poison Poison and Steel types.\nIn Generations 2-4, if a Focus Sash or Focus Band activates before the final hit, subsequent hits do not cause the holder to faint.", "In Generations 1-3, Twineedle ends immediately if any hit breaks a Substitute.", "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."]}
-{"name": "vice grip", "type": "normal", "category": "physical", "power": 55, "accuracy": 1.0, "pp": 30}
-{"name": "vine whip", "type": "grass", "category": "physical", "power": 35, "accuracy": 1.0, "pp": 10}
-{"name": "water gun", "type": "water", "category": "special", "power": 40, "accuracy": 1.0, "pp": 25}
-{"name": "waterfall", "type": "water", "category": "physical", "power": 80, "accuracy": 1.0, "pp": 15}
-{"name": "whirlwind", "type": "normal", "category": "status", "power": null, "accuracy": 0.85, "pp": 20}
-{"name": "wing attack", "type": "flying", "category": "physical", "power": 35, "accuracy": 1.0, "pp": 35}
-{"name": "withdraw", "type": "water", "category": "status", "power": null, "accuracy": null, "pp": 40, "effect": {"stat": "defense", "stages": 1}}
-{"name": "wrap", "type": "normal", "category": "physical", "power": 15, "accuracy": 0.9, "pp": 20, "effects": ["Wrap inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."], "changes": ["In Generations 1-4, Wrap has 85% accuracy. Its after-effects last for 2-5 turns instead of 4-5.", "In Generation 1, Wrap simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."]}
-
+{
+    "name": "absorb",
+    "type": "grass",
+    "category": "special",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effects": [
+        "Absorb deals damage and the user will recover 50% of the HP drained."
+    ]
+}
+{
+    "name": "acid",
+    "type": "poison",
+    "category": "physical",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "chance": 0.1,
+        "stat": "defense",
+        "stages": -1
+    }
+}
+{
+    "name": "acid armor",
+    "type": "poison",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40,
+    "effect": {
+        "stat": "defense",
+        "stages": 2
+    }
+}
+{
+    "name": "agility",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effect": {
+        "stat": "speed",
+        "stages": 2
+    }
+}
+{
+    "name": "amnesia",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20,
+    "effect": {
+        "stat": "special",
+        "stages": 2
+    }
+}
+{
+    "name": "aurora beam",
+    "type": "ice",
+    "category": "special",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "chance": 0.1,
+        "stat": "attack",
+        "stages": -1
+    }
+}
+{
+    "name": "barrage",
+    "type": "normal",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 0.85,
+    "pp": 20,
+    "changes": [
+        "In Generations 1-3, Barrage ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "barrier",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effect": {
+        "stat": "defense",
+        "stages": 2
+    }
+}
+{
+    "name": "bide",
+    "type": "normal",
+    "category": "physical",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "The user of Bide stores energy for 2 turns. At the end of the second turn the Pokémon unleashes energy, dealing twice the HP damage it received.",
+        "Bide deals fixed, typeless damage, so will hit Ghost-type Pokémon. It also ignores changes to the Accuracy and Evasion stats and can hit Pokémon in the invulnerable stage of Bounce, Dig, Dive, Fly, Shadow Force or Sky Drop."
+    ],
+    "changes": [
+        "In Generations 1-3, Bide is not an increased priority move. It also stores energy for 2-3 turns."
+    ]
+}
+{
+    "name": "bind",
+    "type": "normal",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 0.85,
+    "pp": 20,
+    "effects": [
+        "Bind inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns."
+    ],
+    "changes": [
+        "In Generations 1-4, Bind has 75% accuracy. Its after-effects last for 2-5 turns instead of 4-5.",
+        "In Generation 1, Bind simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."
+    ]
+}
+{
+    "name": "bite",
+    "type": "normal",
+    "category": "physical",
+    "power": 60,
+    "accuracy": 1.0,
+    "pp": 25,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "blizzard",
+    "type": "ice",
+    "category": "special",
+    "power": 120,
+    "accuracy": 0.9,
+    "pp": 5,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "freeze"
+    }
+}
+{
+    "name": "body slam",
+    "type": "normal",
+    "category": "physical",
+    "power": 85,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "bone club",
+    "type": "ground",
+    "category": "physical",
+    "power": 65,
+    "accuracy": 0.85,
+    "pp": 20,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "bonemerang",
+    "type": "ground",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 0.9,
+    "pp": 10,
+    "effects": [
+        "Bonemerang deals damage and will strike twice (with 50 base power each time).\nEach strike of Bonemerang is treated like a separate attack:"
+    ],
+    "changes": [
+        "In Generations 1-3, Bonemerang ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "bubble",
+    "type": "water",
+    "category": "special",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "chance": 0.1,
+        "stat": "speed",
+        "stages": -1
+    }
+}
+{
+    "name": "bubble beam",
+    "type": "water",
+    "category": "special",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "chance": 0.1,
+        "stat": "speed",
+        "stages": -1
+    }
+}
+{
+    "name": "clamp",
+    "type": "water",
+    "category": "physical",
+    "power": 35,
+    "accuracy": 0.85,
+    "pp": 10,
+    "effects": [
+        "Clamp inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."
+    ],
+    "changes": [
+        "In Generations 1-4, Clamp has 75% accuracy. Its after-effects last for 2-5 turns instead of 4-5.",
+        "In Generation 1, Clamp simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."
+    ]
+}
+{
+    "name": "comet punch",
+    "type": "normal",
+    "category": "physical",
+    "power": 18,
+    "accuracy": 0.85,
+    "pp": 15,
+    "changes": [
+        "In Generations 1-3, Comet Punch ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "confuse ray",
+    "type": "ghost",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effect": {
+        "statusCondition": "confused"
+    }
+}
+{
+    "name": "confusion",
+    "type": "psychic",
+    "category": "special",
+    "power": 50,
+    "accuracy": 1.0,
+    "pp": 25,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "confused"
+    }
+}
+{
+    "name": "constrict",
+    "type": "normal",
+    "category": "physical",
+    "power": 10,
+    "accuracy": 1.0,
+    "pp": 35,
+    "effect": {
+        "chance": 0.1,
+        "stat": "speed",
+        "stages": -1
+    }
+}
+{
+    "name": "conversion",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "changes": [
+        "In Generation 1, Conversion changes the user's type to the target Pokémon's type."
+    ]
+}
+{
+    "name": "counter",
+    "type": "fighting",
+    "category": "physical",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 20,
+    "priority": -1,
+    "effects": [
+        "When hit by a Physical Attack, user strikes back with 2x power."
+    ]
+}
+{
+    "name": "crabhammer",
+    "type": "water",
+    "category": "physical",
+    "power": 90,
+    "accuracy": 0.85,
+    "pp": 10,
+    "highCriticalHitRatio": true
+}
+{
+    "name": "cut",
+    "type": "normal",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 0.95,
+    "pp": 30
+}
+{
+    "name": "defense curl",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40,
+    "effect": {
+        "stat": "defense",
+        "stages": 1
+    }
+}
+{
+    "name": "dig",
+    "type": "ground",
+    "category": "physical",
+    "power": 60,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "The user of Dig will burrow its way underground on the first turn, disappearing from view and becoming invulnerable to most attacks. On the second turn, Dig deals damage."
+    ]
+}
+{
+    "name": "disable",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.55,
+    "pp": 20,
+    "effects": [
+        "Disable causes the previous move the target used to be disabled for 1-8 turns, which prevents the move's use."
+    ]
+}
+{
+    "name": "dizzy punch",
+    "type": "normal",
+    "category": "physical",
+    "power": 70,
+    "accuracy": 1.0,
+    "pp": 10
+}
+{
+    "name": "double kick",
+    "type": "fighting",
+    "category": "physical",
+    "power": 30,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effects": [
+        "Double Kick deals damage and will strike twice (with 30 base power each time).\nEach strike of Double Kick is treated like a separate attack:"
+    ],
+    "changes": [
+        "In Generations 1-3, Double Kick ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "double slap",
+    "type": "normal",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 0.85,
+    "pp": 10,
+    "effects": [],
+    "changes": [
+        "In Generations 1-3, Double Slap ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest.",
+        "In Generations 1-5, this move's name was formatted as DoubleSlap."
+    ]
+}
+{
+    "name": "double team",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 15,
+    "effect": {
+        "stat": "evasiveness",
+        "stages": 1
+    }
+}
+{
+    "name": "double-edge",
+    "type": "normal",
+    "category": "physical",
+    "power": 100,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [
+        "Double-Edge deals damage, but the user receives 1⁄3 of the damage it inflicted in recoil. In other words, if the attack does 90 HP damage to the opponent, the user will lose 30 HP."
+    ],
+    "changes": [
+        "In Generations 1-2, the recoil is 1⁄4 of the damage inflicted."
+    ]
+}
+{
+    "name": "dragon rage",
+    "type": "dragon",
+    "category": "special",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "Dragon Rage always deals 40 HP damage to the target, regardless of typing. It has no additional effect."
+    ]
+}
+{
+    "name": "dream eater",
+    "type": "psychic",
+    "category": "special",
+    "power": 100,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [
+        "Dream Eater deals damage only on sleeping foes and the user will recover 50% of the HP drained."
+    ]
+}
+{
+    "name": "drill peck",
+    "type": "flying",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 1.0,
+    "pp": 20
+}
+{
+    "name": "earthquake",
+    "type": "ground",
+    "category": "physical",
+    "power": 100,
+    "accuracy": 1.0,
+    "pp": 10
+}
+{
+    "name": "egg bomb",
+    "type": "normal",
+    "category": "physical",
+    "power": 100,
+    "accuracy": 0.75,
+    "pp": 10
+}
+{
+    "name": "ember",
+    "type": "fire",
+    "category": "special",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 25,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "burn"
+    }
+}
+{
+    "name": "explosion",
+    "type": "normal",
+    "category": "physical",
+    "power": 170,
+    "accuracy": 1.0,
+    "pp": 5,
+    "effects": [
+        "Explosion deals high damage, but causes the user to faint."
+    ],
+    "changes": [
+        "In Generations 1-4, the opponent's defense stat is temporarily halved when calculating the damage. This gives Explosion an effective power of 340."
+    ]
+}
+{
+    "name": "fire blast",
+    "type": "fire",
+    "category": "special",
+    "power": 120,
+    "accuracy": 0.85,
+    "pp": 5,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "burn"
+    }
+}
+{
+    "name": "fire punch",
+    "type": "fire",
+    "category": "physical",
+    "power": 75,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "burn"
+    }
+}
+{
+    "name": "fire spin",
+    "type": "fire",
+    "category": "special",
+    "power": 35,
+    "accuracy": 0.85,
+    "pp": 15,
+    "effects": [
+        "Fire Spin inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."
+    ],
+    "changes": [
+        "In Generations 1-4, Fire Spin has a base power of 15 and 70% accuracy. Its after-effects last for 2-5 turns instead of 4-5.",
+        "In Generation 1, Fire Spin simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."
+    ]
+}
+{
+    "name": "fissure",
+    "type": "ground",
+    "category": "physical",
+    "power": null,
+    "accuracy": null,
+    "pp": 5,
+    "effects": [
+        "If it hits, Fissure is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.",
+        "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"
+    ],
+    "changes": [
+        "In Generation 1, Fissure has 30% accuracy and can hit Pokémon of any level, but does not affect Pokémon faster than the user."
+    ]
+}
+{
+    "name": "flamethrower",
+    "type": "fire",
+    "category": "special",
+    "power": 95,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "burn"
+    }
+}
+{
+    "name": "flash",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.7,
+    "pp": 20,
+    "effect": {
+        "stat": "accuracy",
+        "stages": -1
+    }
+}
+{
+    "name": "fly",
+    "type": "flying",
+    "category": "physical",
+    "power": 70,
+    "accuracy": 0.95,
+    "pp": 15,
+    "effects": [
+        "The user of Fly will fly up high on the first turn, disappearing from view and becoming invulnerable to most attacks. On the second turn, Fly deals damage.",
+        "While in the air, the Pokémon can only be hit by the moves Gust, Twister, Thunder, Sky Uppercut and Smack Down, with Gust and Twister dealing twice normal damage. Moves from No Guard Pokémon, or any move following an identify move can also hit for regular power."
+    ]
+}
+{
+    "name": "focus energy",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "highCriticalHitRatio": true
+}
+{
+    "name": "fury attack",
+    "type": "normal",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 0.85,
+    "pp": 20,
+    "effects": [],
+    "changes": [
+        "In Generations 1-3, Fury Attack ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "fury swipes",
+    "type": "normal",
+    "category": "physical",
+    "power": 18,
+    "accuracy": 0.8,
+    "pp": 15,
+    "effects": [],
+    "changes": [
+        "In Generations 1-3, Fury Swipes ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "glare",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.75,
+    "pp": 30,
+    "effect": {
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "growl",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 40,
+    "effect": {
+        "stat": "attack",
+        "stages": -1
+    }
+}
+{
+    "name": "growth",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40,
+    "effect": {
+        "stat": "special",
+        "stages": 1
+    }
+}
+{
+    "name": "guillotine",
+    "type": "normal",
+    "category": "physical",
+    "power": null,
+    "accuracy": null,
+    "pp": 5,
+    "effects": [
+        "If it hits, Guillotine is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.",
+        "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"
+    ],
+    "changes": [
+        "In Generation 1, Guillotine has 30% accuracy, but does not affect opponents faster than the user."
+    ]
+}
+{
+    "name": "gust",
+    "type": "normal",
+    "category": "special",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 35
+}
+{
+    "name": "harden",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effect": {
+        "stat": "defense",
+        "stages": 1
+    }
+}
+{
+    "name": "haze",
+    "type": "ice",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effects": [
+        "Resets all stat changes."
+    ]
+}
+{
+    "name": "headbutt",
+    "type": "normal",
+    "category": "physical",
+    "power": 70,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "high jump kick",
+    "type": "fighting",
+    "category": "physical",
+    "power": 85,
+    "accuracy": 0.9,
+    "pp": 20,
+    "effects": [
+        "High Jump Kick deals damage, however, if it misses the user keeps going and crashes, losing 1⁄2 of its maximum HP. High Jump Kick cannot be used if Gravity is in effect."
+    ],
+    "changes": [
+        "In Generation 1, the crash damage is always 1 HP."
+    ]
+}
+{
+    "name": "horn attack",
+    "type": "normal",
+    "category": "physical",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 25
+}
+{
+    "name": "horn drill",
+    "type": "normal",
+    "category": "physical",
+    "power": null,
+    "accuracy": null,
+    "pp": 5,
+    "effects": [
+        "If it hits, Horn Drill is guaranteed to make the opponent faint. It is more likely to hit Pokémon that are of a lower level than the user.",
+        "Its accuracy (as a percentage) is calculated as below, ignoring all other accuracy and evasion modifiers:"
+    ],
+    "changes": [
+        "In Generation 1, Horn Drill has 30% accuracy, but does not affect opponents faster than the user."
+    ]
+}
+{
+    "name": "hydro pump",
+    "type": "water",
+    "category": "special",
+    "power": 120,
+    "accuracy": 0.8,
+    "pp": 5
+}
+{
+    "name": "hyper beam",
+    "type": "normal",
+    "category": "special",
+    "power": 150,
+    "accuracy": 0.9,
+    "pp": 5,
+    "effects": [
+        "Hyper Beam deals damage, but the user must recharge on the next turn (bringing its effective power down to 75 per turn)."
+    ],
+    "changes": [
+        "In Generation 1, if Hyper Beam KOs a Pokemon, it does not need to recharge."
+    ]
+}
+{
+    "name": "hyper fang",
+    "type": "normal",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 0.9,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "hypnosis",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.6,
+    "pp": 20,
+    "effect": {
+        "statusCondition": "sleep"
+    }
+}
+{
+    "name": "ice beam",
+    "type": "ice",
+    "category": "special",
+    "power": 95,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "freeze"
+    }
+}
+{
+    "name": "ice punch",
+    "type": "ice",
+    "category": "physical",
+    "power": 75,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "freeze"
+    }
+}
+{
+    "name": "jump kick",
+    "type": "fighting",
+    "category": "physical",
+    "power": 70,
+    "accuracy": 0.95,
+    "pp": 25,
+    "effects": [
+        "Jump Kick deals damage, however, if it misses the user keeps going and crashes, losing 1⁄2 of its maximum HP. Jump Kick cannot be used if Gravity is in effect."
+    ],
+    "changes": [
+        "In Generation 1, the crash damage is always 1 HP. From Generation 2 to Generation 4, the crash damage is 1⁄8 of the damage the attack would have inflicted (which could be all of the user's own HP)."
+    ]
+}
+{
+    "name": "karate chop",
+    "type": "normal",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 1.0,
+    "pp": 25,
+    "highCriticalHitRatio": true
+}
+{
+    "name": "kinesis",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.8,
+    "pp": 15,
+    "effect": {
+        "stat": "accuracy",
+        "stages": -1
+    }
+}
+{
+    "name": "leech life",
+    "type": "bug",
+    "category": "physical",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [
+        "Leech Life deals damage and the user will recover 50% of the HP drained."
+    ]
+}
+{
+    "name": "leech seed",
+    "type": "grass",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.9,
+    "pp": 10,
+    "effects": [
+        "Leech Seed plants a seed on the target that drains 1⁄8 of its maximum HP at the end of each turn and restores it to the user, or any Pokemon that takes its place. It does not work on Grass-type Pokemon; it does technically work against Pokemon with the Magic Guard ability, but no HP will be sapped."
+    ],
+    "changes": [
+        "In Generation 1, Leech Seed saps 1⁄16 of the target's HP. If the target is also badly poisoned, the damage increases by 1⁄16 each turn, in the same way as bad poison (and in addition to poison damage).",
+        "In Generation 1 and Generation 2 only, Haze will also clear the effects of Leech Seed."
+    ]
+}
+{
+    "name": "leer",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "stat": "defense",
+        "stages": -1
+    }
+}
+{
+    "name": "lick",
+    "type": "ghost",
+    "category": "physical",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "light screen",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effects": [
+        "Light Screen reduces damage from Special attacks by 50%, for 5 turns. Its effects apply to all Pokémon on the user's side of the field."
+    ]
+}
+{
+    "name": "lovely kiss",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.75,
+    "pp": 10,
+    "effect": {
+        "statusCondition": "sleep"
+    }
+}
+{
+    "name": "low kick",
+    "type": "fighting",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 0.9,
+    "pp": 20,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "meditate",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40,
+    "effect": {
+        "stat": "attack",
+        "stages": 1
+    }
+}
+{
+    "name": "mega drain",
+    "type": "grass",
+    "category": "special",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "Mega Drain deals damage and the user will recover 50% of the HP drained.",
+        "If the user is holding a Big Root, the move instead recovers 65% of the damage dealt (30% more than normal). If used on a Pokemon with the ability Liquid Ooze, the user instead loses the HP it would have otherwise gained."
+    ]
+}
+{
+    "name": "mega kick",
+    "type": "normal",
+    "category": "physical",
+    "power": 120,
+    "accuracy": 0.75,
+    "pp": 5
+}
+{
+    "name": "mega punch",
+    "type": "normal",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 0.85,
+    "pp": 20
+}
+{
+    "name": "metronome",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "User performs any move in the game at random."
+    ]
+}
+{
+    "name": "mimic",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "Mimic copies the last move used by the target (replacing Mimic). The copied move always has 5 PP. The effect only lasts while the user is in battle: if the user switches out or when the battle ends, the move becomes Mimic again.",
+        "Mimic cannot copy Chatter, Metronome, Sketch or Struggle."
+    ],
+    "changes": [
+        "In Generation 1, Mimic allows the user to choose any of the opponent's moves to copy."
+    ]
+}
+{
+    "name": "minimize",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20,
+    "effect": {
+        "stat": "evasiveness",
+        "stages": 1
+    }
+}
+{
+    "name": "mirror move",
+    "type": "flying",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20,
+    "effects": [
+        "User performs the opponent's last move."
+    ]
+}
+{
+    "name": "mist",
+    "type": "ice",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effects": [
+        "User's stats cannot be changed for a period of time."
+    ]
+}
+{
+    "name": "night shade",
+    "type": "ghost",
+    "category": "special",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [
+        "The damage of Night Shade is equal to the user's level. So at level 100 the Pokémon will inflict 100 HP damage."
+    ],
+    "changes": [
+        "In Generation 1, Night Shade also hits Normal- and Psychic-type Pokémon despite their immunity to Ghost-type attacks."
+    ]
+}
+{
+    "name": "pay day",
+    "type": "normal",
+    "category": "physical",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 20
+}
+{
+    "name": "peck",
+    "type": "flying",
+    "category": "physical",
+    "power": 35,
+    "accuracy": 1.0,
+    "pp": 35
+}
+{
+    "name": "petal dance",
+    "type": "grass",
+    "category": "special",
+    "power": 120,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "The user of Petal Dance attacks for 2-3 turns, during which it cannot switch out, and then becomes confused. Confused Pokémon have a 50% chance of hurting themselves each turn, for 1-4 turns. The damage received is as if the Pokémon attacks itself with a typeless 40 base power Physical attack.",
+        "If Petal Dance is disrupted (e.g. if the move misses or the user cannot attack due to paralysis) then it will stop and not cause confusion.",
+        "Pokémon with the ability Own Tempo or those behind a Substitute cannot be confused."
+    ],
+    "changes": [
+        "In Generations 1-3 Petal Dance has a base power of 70. In Generation 4 its base power is 90.",
+        "In Generations 1-4, Petal Dance has 20 PP. Furthermore, sleep, freezing and flinching will pause but not disrupt Petal Dance.",
+        "In Generation 1, Petal Dance lasts for 3-4 turns."
+    ]
+}
+{
+    "name": "pin missile",
+    "type": "bug",
+    "category": "physical",
+    "power": 14,
+    "accuracy": 0.85,
+    "pp": 20,
+    "changes": [
+        "In Generations 1-3, Pin Missile ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "poison gas",
+    "type": "poison",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.55,
+    "pp": 40,
+    "effect": {
+        "statusCondition": "poison"
+    }
+}
+{
+    "name": "poison powder",
+    "type": "poison",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.75,
+    "pp": 35,
+    "effect": {
+        "statusCondition": "poison"
+    }
+}
+{
+    "name": "poison sting",
+    "type": "poison",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 1.0,
+    "pp": 35,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "poison"
+    }
+}
+{
+    "name": "pound",
+    "type": "normal",
+    "category": "physical",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 35
+}
+{
+    "name": "psybeam",
+    "type": "psychic",
+    "category": "special",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "confused"
+    }
+}
+{
+    "name": "psychic",
+    "type": "psychic",
+    "category": "special",
+    "power": 90,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effect": {
+        "chance": 0.3,
+        "stat": "special",
+        "stages": -1
+    }
+}
+{
+    "name": "psywave",
+    "type": "psychic",
+    "category": "special",
+    "power": null,
+    "accuracy": 0.8,
+    "pp": 15,
+    "effects": [
+        "Psywave inflicts a random amount of HP damage, varying between 50% and 150% of the user's level. In other words, at level 100 the damage will be 50-150 HP.",
+        "The damage is typeless (not affected by type advantages/disadvantages) but it still does not affect Dark type Pokemon."
+    ]
+}
+{
+    "name": "quick attack",
+    "type": "normal",
+    "category": "physical",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 30,
+    "priority": 1
+}
+{
+    "name": "rage",
+    "type": "normal",
+    "category": "physical",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effects": [
+        "Rage deals damage, and if the user is hit by a direct attack - any time after Rage is first used but before a different move is used - the user's Attack is raised by one stage. The game will state the Pokemon's rage is building rather than explicitly assert the stat increase. Stats can be raised to a maximum of +6 stages each.",
+        "The Attack increases will continue as long as Rage is the last move used, even if it misses, the user is incapacitated (paralyzed, sleeping, etc) or the player uses an item. The Attack increase activates for every blow of multi-hit moves such as DoubleSlap or Fury Swipes.",
+        "As an example, if a Pokemon uses Rage then the opponent hits the user in the same turn, the user's Attack increases. If the user moves last it will not increase that turn, but will in the next turn if the opponent hits the user again."
+    ],
+    "changes": [
+        "In Generation 1, after Rage is selected it will continue to be used until the end of the battle or the user faints.",
+        "In Generations 2-3, if the user is slower than the opponent, the Attack rise only occurs if Rage is selected in that turn - if a different move is selected (or an item used) and the Pokemon is hit before it uses the new move, its Attack does not increase."
+    ]
+}
+{
+    "name": "razor leaf",
+    "type": "grass",
+    "category": "physical",
+    "power": 55,
+    "accuracy": 0.95,
+    "pp": 25,
+    "highCriticalHitRatio": true
+}
+{
+    "name": "razor wind",
+    "type": "normal",
+    "category": "special",
+    "power": 80,
+    "accuracy": 0.75,
+    "pp": 10,
+    "effects": [
+        "The user of Razor Wind will whip up a whirlwind on the first turn. On the second turn, Razor Wind deals damage."
+    ]
+}
+{
+    "name": "recover",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20,
+    "effects": [
+        "Recover restores up to 50% of the user's maximum HP."
+    ]
+}
+{
+    "name": "reflect",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20,
+    "effects": [
+        "Reflect reduces damage from Physical attacks by 50%, for 5 turns. Its effects apply to all Pokémon on the user's side of the field."
+    ]
+}
+{
+    "name": "rest",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "User sleeps for 2 turns, but user is fully healed."
+    ]
+}
+{
+    "name": "roar",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 20
+}
+{
+    "name": "rock slide",
+    "type": "rock",
+    "category": "physical",
+    "power": 75,
+    "accuracy": 0.9,
+    "pp": 10,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "rock throw",
+    "type": "rock",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 0.65,
+    "pp": 15
+}
+{
+    "name": "rolling kick",
+    "type": "fighting",
+    "category": "physical",
+    "power": 60,
+    "accuracy": 0.85,
+    "pp": 15,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "sand attack",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "stat": "accuracy",
+        "stages": -1
+    }
+}
+{
+    "name": "scratch",
+    "type": "normal",
+    "category": "physical",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 35
+}
+{
+    "name": "screech",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.85,
+    "pp": 40,
+    "effect": {
+        "stat": "defense",
+        "stages": -2
+    }
+}
+{
+    "name": "seismic toss",
+    "type": "fighting",
+    "category": "physical",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effects": [
+        "The damage of Seismic Toss is equal to the user's level. So at level 100 the Pokémon will inflict 100 HP damage."
+    ],
+    "changes": [
+        "In Generation 1 Seismic Toss can hit Ghost-type Pokémon despite their immunity to Fighting-type attacks."
+    ]
+}
+{
+    "name": "self-destruct",
+    "type": "normal",
+    "category": "physical",
+    "power": 200,
+    "accuracy": 1.0,
+    "pp": 5,
+    "effects": [
+        "Self-Destruct deals high damage, but causes the user to faint."
+    ]
+}
+{
+    "name": "sharpen",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effect": {
+        "stat": "attack",
+        "stages": 1
+    }
+}
+{
+    "name": "sing",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.55,
+    "pp": 15,
+    "effect": {
+        "statusCondition": "sleep"
+    }
+}
+{
+    "name": "skull bash",
+    "type": "normal",
+    "category": "physical",
+    "power": 100,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [
+        "The user of Skull Bash will tuck in its head on the first turn and raise its Defense by one stage. On the second turn, Skull Bash deals damage."
+    ],
+    "changes": [
+        "In Generation 1, Skull Bash does not raise the user's Defense."
+    ]
+}
+{
+    "name": "sky attack",
+    "type": "flying",
+    "category": "physical",
+    "power": 140,
+    "accuracy": 0.9,
+    "pp": 5,
+    "effects": [
+        "The user of Sky Attack will become cloaked in a harsh light on the first turn. On the second turn, Sky Attack deals damage."
+    ]
+}
+{
+    "name": "slam",
+    "type": "normal",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 0.75,
+    "pp": 20
+}
+{
+    "name": "slash",
+    "type": "normal",
+    "category": "physical",
+    "power": 70,
+    "accuracy": 1.0,
+    "pp": 20,
+    "highCriticalHitRatio": true
+}
+{
+    "name": "sleep powder",
+    "type": "grass",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.75,
+    "pp": 15,
+    "effect": {
+        "statusCondition": "sleep"
+    }
+}
+{
+    "name": "sludge",
+    "type": "poison",
+    "category": "special",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "poison"
+    }
+}
+{
+    "name": "smog",
+    "type": "poison",
+    "category": "special",
+    "power": 20,
+    "accuracy": 0.7,
+    "pp": 20,
+    "effect": {
+        "chance": 0.4,
+        "statusCondition": "poison"
+    }
+}
+{
+    "name": "smokescreen",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "stat": "accuracy",
+        "stages": -1
+    }
+}
+{
+    "name": "soft-boiled",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "Soft-Boiled recovers up to 50% of the user's maximum HP."
+    ]
+}
+{
+    "name": "solar beam",
+    "type": "grass",
+    "category": "special",
+    "power": 120,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "The user of Solar Beam will absorb light on the first turn. On the second turn, Solar Beam deals damage."
+    ]
+}
+{
+    "name": "sonic boom",
+    "type": "normal",
+    "category": "special",
+    "power": null,
+    "accuracy": 0.9,
+    "pp": 20,
+    "effects": [
+        "Sonic Boom always deals 20 HP damage to the target, regardless of typing (although Ghost type Pokémon are still immune). It has no additional effect."
+    ],
+    "changes": [
+        "In Generation 1, Sonic Boom hits Ghost types regardless of their immunity to Normal type moves."
+    ]
+}
+{
+    "name": "spike cannon",
+    "type": "normal",
+    "category": "physical",
+    "power": 20,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effects": [],
+    "changes": [
+        "In Generations 1-3, Spike Cannon ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "splash",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40
+}
+{
+    "name": "spore",
+    "type": "grass",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "statusCondition": "sleep"
+    }
+}
+{
+    "name": "stomp",
+    "type": "normal",
+    "category": "physical",
+    "power": 65,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "chance": 0.3,
+        "statusCondition": "flinch"
+    }
+}
+{
+    "name": "strength",
+    "type": "normal",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 1.0,
+    "pp": 15
+}
+{
+    "name": "string shot",
+    "type": "bug",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.95,
+    "pp": 40,
+    "effect": {
+        "stat": "speed",
+        "stages": -1
+    }
+}
+{
+    "name": "struggle",
+    "type": "normal",
+    "category": "physical",
+    "power": 50,
+    "accuracy": 1.0,
+    "pp": null,
+    "effects": [
+        "Only usable when all PP are gone. Hurts the user."
+    ]
+}
+{
+    "name": "stun spore",
+    "type": "grass",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.75,
+    "pp": 30,
+    "effect": {
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "submission",
+    "type": "fighting",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 0.8,
+    "pp": 25,
+    "effects": [
+        "Submission deals damage, but the user receives 1⁄4 of the damage it inflicts in recoil. In other words, if the attack does 100 HP damage to the opponent, the user will lose 25 HP."
+    ]
+}
+{
+    "name": "substitute",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "Uses HP to creates a decoy that takes hits."
+    ]
+}
+{
+    "name": "super fang",
+    "type": "normal",
+    "category": "physical",
+    "power": null,
+    "accuracy": 0.9,
+    "pp": 10,
+    "effects": [
+        "Always takes off half of the opponent's HP."
+    ]
+}
+{
+    "name": "supersonic",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.55,
+    "pp": 20,
+    "effect": {
+        "statusCondition": "confused"
+    }
+}
+{
+    "name": "surf",
+    "type": "water",
+    "category": "special",
+    "power": 95,
+    "accuracy": 1.0,
+    "pp": 15
+}
+{
+    "name": "swift",
+    "type": "normal",
+    "category": "special",
+    "power": 60,
+    "accuracy": null,
+    "pp": 20,
+    "changes": [
+        "In Generation 1, Swift can hit Pokémon during the invulnerable stage of Dig and Fly."
+    ]
+}
+{
+    "name": "swords dance",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 30,
+    "effect": {
+        "stat": "attack",
+        "stages": 2
+    }
+}
+{
+    "name": "tackle",
+    "type": "normal",
+    "category": "physical",
+    "power": 35,
+    "accuracy": 0.95,
+    "pp": 35
+}
+{
+    "name": "tail whip",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "stat": "defense",
+        "stages": -1
+    }
+}
+{
+    "name": "take down",
+    "type": "normal",
+    "category": "physical",
+    "power": 90,
+    "accuracy": 0.85,
+    "pp": 20,
+    "effects": [
+        "Take Down deals damage, but the user receives 1⁄4 of the damage it inflicted in recoil. In other words, if the attack does 100 HP damage to the opponent, the user will lose 25 HP."
+    ]
+}
+{
+    "name": "teleport",
+    "type": "psychic",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 20
+}
+{
+    "name": "thrash",
+    "type": "normal",
+    "category": "physical",
+    "power": 120,
+    "accuracy": 1.0,
+    "pp": 10,
+    "effects": [
+        "The user of Thrash attacks for 2-3 turns, during which it cannot switch out, and then becomes confused. Confused Pokémon have a 50% chance of hurting themselves each turn, for 1-4 turns. The damage received is as if the Pokémon attacks itself with a typeless 40 base power Physical attack.",
+        "If Thrash is disrupted (e.g. if the move misses or the user cannot attack due to paralysis) then it will stop and not cause confusion.",
+        "Pokémon with the ability Own Tempo or those behind a Substitute cannot be confused."
+    ],
+    "changes": [
+        "In Generations 1-4, Thrash has 20 PP and a base power of 90. Furthermore, sleep, freezing and flinching will pause but not disrupt Thrash.",
+        "In Generation 1, Thrash lasts for 3-4 turns."
+    ]
+}
+{
+    "name": "thunder",
+    "type": "electric",
+    "category": "special",
+    "power": 120,
+    "accuracy": 0.7,
+    "pp": 10,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "thunder punch",
+    "type": "electric",
+    "category": "physical",
+    "power": 75,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "thunder shock",
+    "type": "electric",
+    "category": "special",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 30,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "thunder wave",
+    "type": "electric",
+    "category": "status",
+    "power": null,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effect": {
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "thunderbolt",
+    "type": "electric",
+    "category": "special",
+    "power": 95,
+    "accuracy": 1.0,
+    "pp": 15,
+    "effect": {
+        "chance": 0.1,
+        "statusCondition": "paralysis"
+    }
+}
+{
+    "name": "toxic",
+    "type": "poison",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.85,
+    "pp": 10,
+    "changes": [
+        "In Generation 1, Toxic also increases the damage taken by Leech Seed."
+    ],
+    "effect": {
+        "statusCondition": "badly poison"
+    }
+}
+{
+    "name": "transform",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 10,
+    "effects": [
+        "User takes on the form and attacks of the opponent."
+    ]
+}
+{
+    "name": "tri attack",
+    "type": "normal",
+    "category": "special",
+    "power": 80,
+    "accuracy": 1.0,
+    "pp": 10
+}
+{
+    "name": "twineedle",
+    "type": "bug",
+    "category": "physical",
+    "power": 25,
+    "accuracy": 1.0,
+    "pp": 20,
+    "effects": [
+        "Twineedle deals damage and will strike twice (with 25 base power each time). It has a 20% chance of poisoning the target. Poison or Steel type Pokémon, those with the ability Immunity or those behind a Substitute cannot be poisoned.\nEach strike of Twineedle is treated like a separate attack:"
+    ],
+    "changes": [
+        "In Generations 1-2, Twineedle can poison Poison and Steel types.\nIn Generations 2-4, if a Focus Sash or Focus Band activates before the final hit, subsequent hits do not cause the holder to faint.",
+        "In Generations 1-3, Twineedle ends immediately if any hit breaks a Substitute.",
+        "In Generation 1, each hit will always deal the same damage - if the first critical hits, so will the rest."
+    ]
+}
+{
+    "name": "vice grip",
+    "type": "normal",
+    "category": "physical",
+    "power": 55,
+    "accuracy": 1.0,
+    "pp": 30
+}
+{
+    "name": "vine whip",
+    "type": "grass",
+    "category": "physical",
+    "power": 35,
+    "accuracy": 1.0,
+    "pp": 10
+}
+{
+    "name": "water gun",
+    "type": "water",
+    "category": "special",
+    "power": 40,
+    "accuracy": 1.0,
+    "pp": 25
+}
+{
+    "name": "waterfall",
+    "type": "water",
+    "category": "physical",
+    "power": 80,
+    "accuracy": 1.0,
+    "pp": 15
+}
+{
+    "name": "whirlwind",
+    "type": "normal",
+    "category": "status",
+    "power": null,
+    "accuracy": 0.85,
+    "pp": 20
+}
+{
+    "name": "wing attack",
+    "type": "flying",
+    "category": "physical",
+    "power": 35,
+    "accuracy": 1.0,
+    "pp": 35
+}
+{
+    "name": "withdraw",
+    "type": "water",
+    "category": "status",
+    "power": null,
+    "accuracy": null,
+    "pp": 40,
+    "effect": {
+        "stat": "defense",
+        "stages": 1
+    }
+}
+{
+    "name": "wrap",
+    "type": "normal",
+    "category": "physical",
+    "power": 15,
+    "accuracy": 0.9,
+    "pp": 20,
+    "effects": [
+        "Wrap inflicts damage on the first turn then traps the opponent, causing them to lose 1⁄16 of their maximum HP after each turn, for 4-5 turns. If the user holds a Grip Claw then it is always 5 turns."
+    ],
+    "changes": [
+        "In Generations 1-4, Wrap has 85% accuracy. Its after-effects last for 2-5 turns instead of 4-5.",
+        "In Generation 1, Wrap simply inflicts its base power damage for 2-5 turns. While in effect, the target is unable to attack."
+    ]
+}

--- a/src/pokemon/mod.rs
+++ b/src/pokemon/mod.rs
@@ -29,18 +29,18 @@ impl Pokemon {
         // TODO: Make this function one that takes in a HashMap of all constructed pokemon, that being handled separately
         // By a utility function in an external file.
         // Pass in only a name and this retrieves the Pokemon with all of its preset stats and moves.
-        let mut name: String = String::new();
+        let name: String = String::new();
         // let results = creator_helper();
-        let mut type_1: Types = Types::Normal;
-        let mut type_2: Option<Types> = None;
-        let mut max_hp: f64 = 0.0;
-        let mut hp: f64 = 0.0;
-        let mut attack: u16 = 0;
-        let mut defense: u16 = 0;
-        let mut special_attack: u16 = 0;
-        let mut special_defense: u16 = 0;
-        let mut speed: u16 = 0;
-        let mut status_conditions: Status = Status {
+        let type_1: Types = Types::Normal;
+        let type_2: Option<Types> = None;
+        let max_hp: f64 = 0.0;
+        let hp: f64 = 0.0;
+        let attack: u16 = 0;
+        let defense: u16 = 0;
+        let special_attack: u16 = 0;
+        let special_defense: u16 = 0;
+        let speed: u16 = 0;
+        let status_conditions: Status = Status {
             non_vol: None,
             vol: Vec::new(),
             turn_count: 0,
@@ -79,46 +79,6 @@ impl Pokemon {
         }
     }
 
-    // Handles assigning a non-volatile status condition to the Pokemon on the field.
-    // If no status condition, assigns a status condition
-    // If a status condition already exists, prints out the prompts
-    // Panics if a fainted Pokemon is still on the field
-    fn non_volatile_status_check(&mut self, incoming_status: NonVolatileStatusType) {
-        match &self.status_conditions.non_vol {
-            None => {
-                self.status_conditions.non_vol = Some(incoming_status);
-                self.status_conditions.turn_count = 1;
-            }
-            // If we're already statused and someone's trying to status us again,
-            // we print out that we're already afflicted with status X
-            Some(non_volatile_condition) => {
-                print!("{} is already ", self.name);
-                match non_volatile_condition {
-                    NonVolatileStatusType::Freeze => println!("Frozen!"),
-                    NonVolatileStatusType::Paralysis => println!("Paralyzed!"),
-                    NonVolatileStatusType::Burn => println!("Burned!"),
-                    NonVolatileStatusType::Sleep => println!("Sleeping!"),
-                    NonVolatileStatusType::Fainted => panic!("We should not be here!"),
-                    _ => println!("Poisoned!"), // Toxic and Poison case
-                }
-            }
-        }
-    }
-
-    // Handles assigning a volatile status condition to the Pokemon on the field
-    fn volatile_status_check(&mut self, incoming_status: VolatileStatusType) {
-        let mut new_status_flag: bool = true;
-        self.status_conditions.vol.iter().for_each(|status| {
-            if incoming_status == status.as_ref().unwrap().0 {
-                println!("But it failed!");
-                new_status_flag = false;
-            }
-        });
-        if new_status_flag == true {
-            self.status_conditions.vol.push(Some((incoming_status, 1)));
-        }
-    }
-
     // Wrapper function for the faint check in the context of direct damage
     pub fn take_attack_damage(&mut self, incoming_damage: f64) {
         self.faint_check(incoming_damage);
@@ -132,7 +92,7 @@ impl Pokemon {
     }
 
     // Reads the relevant moveset from the file and returns it as a vector of strings
-    pub fn construct_moveset(&mut self, moves: Vec<String>) {
+    pub fn construct_moveset(&mut self, _moves: Vec<String>) {
         // TODO: Let a vector of strings be used to select moves out of the overall moveset of Gen 1
         // Assign moves in order of their placement in the vector.
         todo!();
@@ -234,14 +194,18 @@ pub mod pokemon_tests {
 
         // Single-instance status damage test
         reset(&mut bulbasaur);
-        bulbasaur.non_volatile_status_check(NonVolatileStatusType::Poison);
+        bulbasaur
+            .status_conditions
+            .non_volatile_status_check(NonVolatileStatusType::Poison, &bulbasaur.name);
         bulbasaur.take_status_damage();
         assert_eq!(bulbasaur.hp, 87.5);
 
         // Multi-instance poison damage and faint test
         bulbasaur.hp = 100.0;
         bulbasaur.status_conditions.non_vol = None;
-        bulbasaur.non_volatile_status_check(NonVolatileStatusType::Poison);
+        bulbasaur
+            .status_conditions
+            .non_volatile_status_check(NonVolatileStatusType::Poison, &bulbasaur.name);
         bulbasaur.take_status_damage();
         assert_eq!(bulbasaur.hp, 87.5);
         bulbasaur.take_status_damage();
@@ -268,7 +232,9 @@ pub mod pokemon_tests {
     fn test_toxic_damage() {
         let mut bulbasaur: Pokemon = creator_helper();
 
-        bulbasaur.non_volatile_status_check(NonVolatileStatusType::Toxic);
+        bulbasaur
+            .status_conditions
+            .non_volatile_status_check(NonVolatileStatusType::Toxic, &bulbasaur.name);
         assert_eq!(
             bulbasaur.status_conditions.non_vol,
             Some(NonVolatileStatusType::Toxic)

--- a/src/statuses/mod.rs
+++ b/src/statuses/mod.rs
@@ -91,7 +91,7 @@ impl Status {
             None => non_vol_and_vol_damage.0 = 0.0,
         }
 
-        for vol_status in self.vol.iter_mut() {
+        self.vol.iter_mut().for_each(|vol_status| {
             match vol_status {
                 Some(condition) => match condition.0 {
                     VolatileStatusType::Bound => {
@@ -114,7 +114,7 @@ impl Status {
                 },
                 None => non_vol_and_vol_damage.1 = 0.0,
             }
-        }
+        });
         non_vol_and_vol_damage
     }
 }
@@ -136,22 +136,157 @@ mod status_types_tests {
         match status_tester.non_vol {
             Some(NonVolatileStatusType::Freeze) => {
                 assert_eq!(status_tester.turn_count, 1);
-                status_tester.turn_count += 1;
             }
             _ => panic!("Freeze status did not work."),
         }
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 0.0);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 2);
 
         // Paralysis test
+        status_tester.non_vol = Some(NonVolatileStatusType::Paralysis);
+        status_tester.turn_count = 1;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Paralysis) => {
+                assert_eq!(status_tester.turn_count, 1);
+            }
+            _ => panic!("Paralysis status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 0.0);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 1);
 
         // Poison test
+        status_tester.non_vol = Some(NonVolatileStatusType::Poison);
+        status_tester.turn_count = 1;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Poison) => {
+                assert_eq!(status_tester.turn_count, 1);
+            }
+            _ => panic!("Poison status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 12.5);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 1);
 
         // Burn test
+        status_tester.non_vol = Some(NonVolatileStatusType::Burn);
+        status_tester.turn_count = 1;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Burn) => {
+                assert_eq!(status_tester.turn_count, 1);
+            }
+            _ => panic!("Burn status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 6.25);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 1);
 
         // Toxic test
+        status_tester.non_vol = Some(NonVolatileStatusType::Toxic);
+        status_tester.turn_count = 4;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Toxic) => {
+                assert_eq!(status_tester.turn_count, 5);
+            }
+            _ => panic!("Toxic status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 25.0);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 5);
 
         // Sleep test
+        status_tester.non_vol = Some(NonVolatileStatusType::Sleep);
+        status_tester.turn_count = 1;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Sleep) => {
+                assert_eq!(status_tester.turn_count, 2);
+            }
+            _ => panic!("Sleep status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Fainted));
+        assert_eq!(res.0, 0.0);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 2);
 
         // Fainted test
+        status_tester.non_vol = Some(NonVolatileStatusType::Fainted);
+        status_tester.turn_count = 1;
+        let res: (f64, f64) = status_tester.damage(&100.0);
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Fainted) => {
+                assert_eq!(status_tester.turn_count, 1);
+            }
+            _ => panic!("Fainted status did not work."),
+        }
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Freeze));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Burn));
+        assert_ne!(
+            status_tester.non_vol,
+            Some(NonVolatileStatusType::Paralysis)
+        );
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Sleep));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Toxic));
+        assert_ne!(status_tester.non_vol, Some(NonVolatileStatusType::Poison));
+        assert_eq!(res.0, 0.0);
+        assert_eq!(res.1, 0.0);
+        assert_eq!(status_tester.turn_count, 1);
     }
 
     #[test]

--- a/src/statuses/mod.rs
+++ b/src/statuses/mod.rs
@@ -1,52 +1,124 @@
 pub trait Damage {
-    fn status_damage(&self, max_hp: &f64) -> f64;
+    fn status_damage(&self, max_hp: &f64, turn_count: &u8) -> f64;
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum NonVolatileStatusType {
-    Freeze(u8),
+    Freeze,
     Paralysis,
     Poison,
     Burn,
-    Toxic(u8),
-    Sleep(u8),
+    Toxic,
+    Sleep,
     Fainted,
 }
 
 impl Damage for NonVolatileStatusType {
-    fn status_damage(&self, max_hp: &f64) -> f64 {
+    fn status_damage(&self, max_hp: &f64, turn_count: &u8) -> f64 {
         match &self {
             Self::Poison => 0.125 * max_hp,
             Self::Burn => 0.0625 * max_hp,
-            Self::Toxic(turn_count) => (*turn_count as f64) * 0.0625 * max_hp,
+            Self::Toxic => (*turn_count as f64) * 0.0625 * max_hp,
             Self::Fainted => panic!("Fainted damage is not calculated."),
-            _ => 0.0,
+            _ => 0.0, // Sleep, Freeze, Paralysis
         }
     }
 }
 
 // Only Gen 1 volatile status types are included below.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum VolatileStatusType {
-    Bound(u8),
-    Confusion(u8),
+    Bound,
+    Confusion,
     Flinch,
     Seeded,
-    Rampage(u8),    // Used for Thrash and Petal Dance to lock the user in.
-    Charging(u8), // Used for Sky Attack, Solar Beam, Fly, Dig, Razor Wind, and Skull Bash to stop attacking for the first turn
-    Recharging(u8), // Used for Hyper Beam to stop attacking for one turn
+    Rampage,    // Used for Thrash and Petal Dance to lock the user in.
+    Charging, // Used for Sky Attack, Solar Beam, Fly, Dig, Razor Wind, and Skull Bash to stop attacking for the first turn
+    Recharging, // Used for Hyper Beam to stop attacking for one turn
 }
 
 impl Damage for VolatileStatusType {
-    fn status_damage(&self, max_hp: &f64) -> f64 {
+    fn status_damage(&self, max_hp: &f64, turn_count: &u8) -> f64 {
         match &self {
-            Self::Bound(_turn_count) => max_hp * 0.0625,
-            Self::Confusion(_turn_count) => 0.0, // TODO: Implement confusion damage
+            Self::Bound => max_hp * 0.0625,
+            Self::Confusion => 0.0, // TODO: Implement confusion damage
             Self::Seeded => max_hp * 0.125,
             _ => 0.0,
         }
     }
 }
+
+pub struct Status {
+    pub non_vol: Option<NonVolatileStatusType>,
+    pub vol: Vec<Option<(VolatileStatusType, u8)>>, // (volatile_status, turn_count_unique_to_that_specific_volatile_status)
+    pub turn_count: u8,
+}
+
+impl Status {
+    pub fn damage(&mut self, max_hp: &f64) -> (f64, f64) {
+        let mut non_vol_and_vol_damage: (f64, f64) = (0.0, 0.0);
+        match &self.non_vol {
+            Some(non_vol_status) => match non_vol_status {
+                NonVolatileStatusType::Poison => {
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count)
+                }
+                NonVolatileStatusType::Burn => {
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count)
+                }
+                NonVolatileStatusType::Toxic => {
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count);
+                    self.turn_count += 1;
+                }
+                NonVolatileStatusType::Fainted => {
+                    // This panics in the trait implementaiton
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count);
+                }
+                NonVolatileStatusType::Paralysis => {
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count);
+                }
+                _ => {
+                    // Sleep and Freeze cases
+                    non_vol_and_vol_damage.0 =
+                        non_vol_status.status_damage(max_hp, &self.turn_count);
+                    self.turn_count += 1;
+                }
+            },
+            None => non_vol_and_vol_damage.0 = 0.0,
+        }
+
+        for vol_status in self.vol.iter_mut() {
+            match vol_status {
+                Some(condition) => match condition.0 {
+                    VolatileStatusType::Bound => {
+                        non_vol_and_vol_damage.1 +=
+                            condition.0.status_damage(max_hp, &self.turn_count);
+                        condition.1 += 1;
+                    }
+                    VolatileStatusType::Seeded => {
+                        non_vol_and_vol_damage.1 +=
+                            condition.0.status_damage(max_hp, &self.turn_count);
+                        condition.1 += 1;
+                    }
+                    VolatileStatusType::Confusion => {}
+                    _ => {
+                        // Flinch, Charging, Recharging, Rampage case
+                        non_vol_and_vol_damage.1 +=
+                            condition.0.status_damage(max_hp, &self.turn_count);
+                        condition.1 += 1;
+                    }
+                },
+                None => non_vol_and_vol_damage.1 = 0.0,
+            }
+        }
+        non_vol_and_vol_damage
+    }
+}
+
 #[cfg(test)]
 mod status_types_tests {
     use super::*;
@@ -54,303 +126,50 @@ mod status_types_tests {
     #[should_panic]
     fn test_non_volatile_status() {
         // All non-volatile status types
-        let paralyze: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Paralysis);
-        let poison: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Poison);
-        let burn: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Burn);
-        let fainted: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Fainted);
-        let mut toxic: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Toxic(1));
-        let mut sleep: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Sleep(1));
-        let mut frozen: Option<NonVolatileStatusType> = Some(NonVolatileStatusType::Freeze(1));
+        let mut status_tester: Status = Status {
+            non_vol: Some(NonVolatileStatusType::Freeze),
+            vol: Vec::new(),
+            turn_count: 1,
+        };
 
         // Frozen test
-        match frozen {
-            Some(NonVolatileStatusType::Freeze(turn_count)) => {
-                // Check initial value of the enum and then increment via reassignment and check again
-                assert_eq!(1, turn_count);
-                frozen = Some(NonVolatileStatusType::Freeze(turn_count + 1));
-                assert_eq!(frozen, Some(NonVolatileStatusType::Freeze(2)));
+        match status_tester.non_vol {
+            Some(NonVolatileStatusType::Freeze) => {
+                assert_eq!(status_tester.turn_count, 1);
+                status_tester.turn_count += 1;
             }
-            _ => panic!("Frozen test failed."),
+            _ => panic!("Freeze status did not work."),
         }
-        assert_ne!(frozen, Some(NonVolatileStatusType::Sleep(2)));
-        assert_ne!(frozen, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(frozen, Some(NonVolatileStatusType::Burn));
-        assert_ne!(frozen, Some(NonVolatileStatusType::Poison));
-        assert_ne!(frozen, Some(NonVolatileStatusType::Toxic(1)));
-        assert_ne!(frozen, Some(NonVolatileStatusType::Freeze(1)));
-        assert_eq!(0.0, frozen.as_ref().unwrap().status_damage(&100.0));
 
         // Paralysis test
-        match paralyze {
-            Some(NonVolatileStatusType::Paralysis) => {
-                assert_eq!(paralyze, Some(NonVolatileStatusType::Paralysis));
-            }
-            _ => panic!("Paralysis test failed."),
-        }
-        assert_ne!(paralyze, Some(NonVolatileStatusType::Sleep(2)));
-        assert_ne!(paralyze, Some(NonVolatileStatusType::Burn));
-        assert_ne!(paralyze, Some(NonVolatileStatusType::Poison));
-        assert_ne!(paralyze, Some(NonVolatileStatusType::Toxic(1)));
-        assert_ne!(paralyze, Some(NonVolatileStatusType::Freeze(1)));
-        assert_eq!(0.0, paralyze.as_ref().unwrap().status_damage(&100.0));
 
         // Poison test
-        match poison {
-            Some(NonVolatileStatusType::Poison) => {
-                assert_eq!(poison, Some(NonVolatileStatusType::Poison))
-            }
-            _ => panic!("Poison test failed."),
-        }
-        assert_ne!(poison, Some(NonVolatileStatusType::Sleep(2)));
-        assert_ne!(poison, Some(NonVolatileStatusType::Burn));
-        assert_ne!(poison, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(poison, Some(NonVolatileStatusType::Toxic(1)));
-        assert_ne!(poison, Some(NonVolatileStatusType::Freeze(1)));
-        assert_eq!(12.5, poison.as_ref().unwrap().status_damage(&100.0));
 
         // Burn test
-        match burn {
-            Some(NonVolatileStatusType::Burn) => {
-                assert_eq!(burn, Some(NonVolatileStatusType::Burn))
-            }
-            _ => panic!("Burn test failed."),
-        }
-        assert_ne!(burn, Some(NonVolatileStatusType::Sleep(78)));
-        assert_ne!(burn, Some(NonVolatileStatusType::Poison));
-        assert_ne!(burn, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(burn, Some(NonVolatileStatusType::Toxic(21)));
-        assert_ne!(burn, Some(NonVolatileStatusType::Freeze(0)));
-        assert_eq!(6.25, burn.as_ref().unwrap().status_damage(&100.0));
 
         // Toxic test
-        match toxic {
-            Some(NonVolatileStatusType::Toxic(_toxic_count)) => {
-                assert_eq!(toxic, Some(NonVolatileStatusType::Toxic(1)));
-                toxic = Some(NonVolatileStatusType::Toxic(2));
-                assert_eq!(toxic, Some(NonVolatileStatusType::Toxic(2)));
-                assert_ne!(toxic, Some(NonVolatileStatusType::Toxic(3)));
-            }
-            _ => panic!("Toxic test failed."),
-        }
-        assert_ne!(toxic, Some(NonVolatileStatusType::Sleep(78)));
-        assert_ne!(toxic, Some(NonVolatileStatusType::Poison));
-        assert_ne!(toxic, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(toxic, Some(NonVolatileStatusType::Burn));
-        assert_ne!(toxic, Some(NonVolatileStatusType::Freeze(0)));
-        assert_ne!(toxic, Some(NonVolatileStatusType::Toxic(38)));
-        assert_eq!(12.5, toxic.as_ref().unwrap().status_damage(&100.0));
 
         // Sleep test
-        match sleep {
-            Some(NonVolatileStatusType::Sleep(_sleep_count)) => {
-                assert_eq!(sleep, Some(NonVolatileStatusType::Sleep(1)));
-                sleep = Some(NonVolatileStatusType::Sleep(2));
-                assert_eq!(sleep, Some(NonVolatileStatusType::Sleep(2)));
-                assert_ne!(sleep, Some(NonVolatileStatusType::Sleep(3)));
-            }
-            _ => panic!("Sleep test failed."),
-        }
-        assert_ne!(sleep, Some(NonVolatileStatusType::Sleep(78)));
-        assert_ne!(sleep, Some(NonVolatileStatusType::Poison));
-        assert_ne!(sleep, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(sleep, Some(NonVolatileStatusType::Burn));
-        assert_ne!(sleep, Some(NonVolatileStatusType::Freeze(0)));
-        assert_ne!(sleep, Some(NonVolatileStatusType::Toxic(38)));
-        assert_eq!(0.0, sleep.as_ref().unwrap().status_damage(&100.0));
 
         // Fainted test
-        match fainted {
-            Some(NonVolatileStatusType::Fainted) => {
-                assert_eq!(fainted, Some(NonVolatileStatusType::Fainted))
-            }
-            _ => panic!("Fainted test failed."),
-        }
-        assert_ne!(fainted, burn);
-        assert_ne!(fainted, sleep);
-        assert_ne!(fainted, toxic);
-        assert_ne!(fainted, poison);
-        assert_ne!(fainted, paralyze);
-        assert_ne!(fainted, frozen);
-        assert_ne!(fainted, Some(NonVolatileStatusType::Sleep(78)));
-        assert_ne!(fainted, Some(NonVolatileStatusType::Poison));
-        assert_ne!(fainted, Some(NonVolatileStatusType::Burn));
-        assert_ne!(fainted, Some(NonVolatileStatusType::Paralysis));
-        assert_ne!(fainted, Some(NonVolatileStatusType::Toxic(21)));
-        assert_ne!(fainted, Some(NonVolatileStatusType::Freeze(0)));
-        assert_eq!(0.0, fainted.as_ref().unwrap().status_damage(&100.0));
     }
 
     #[test]
     fn test_volatile_status() {
         // All volatile status types
-        let mut bound: Option<VolatileStatusType> = Some(VolatileStatusType::Bound(1));
-        let mut confusion: Option<VolatileStatusType> = Some(VolatileStatusType::Confusion(1));
-        let flinch: Option<VolatileStatusType> = Some(VolatileStatusType::Flinch);
-        let seeded: Option<VolatileStatusType> = Some(VolatileStatusType::Seeded);
-        let mut rampage: Option<VolatileStatusType> = Some(VolatileStatusType::Rampage(1));
-        let mut charging: Option<VolatileStatusType> = Some(VolatileStatusType::Charging(1));
-        let mut recharging: Option<VolatileStatusType> = Some(VolatileStatusType::Recharging(1));
 
         // BOUND TEST
-        match bound {
-            Some(VolatileStatusType::Bound(bind_count)) => {
-                assert_eq!(bound, Some(VolatileStatusType::Bound(1)));
-                assert_eq!(bind_count, 1);
-                bound = Some(VolatileStatusType::Bound(2));
-                assert_eq!(bound, Some(VolatileStatusType::Bound(2)));
-            }
-            _ => panic!("Bind test failed"),
-        }
-        assert_ne!(bound, confusion);
-        assert_ne!(bound, flinch);
-        assert_ne!(bound, seeded);
-        assert_ne!(bound, rampage);
-        assert_ne!(bound, charging);
-        assert_ne!(bound, recharging);
-        assert_ne!(bound, Some(VolatileStatusType::Confusion(1)));
-        assert_ne!(bound, Some(VolatileStatusType::Flinch));
-        assert_ne!(bound, Some(VolatileStatusType::Seeded));
-        assert_ne!(bound, Some(VolatileStatusType::Rampage(38)));
-        assert_ne!(bound, Some(VolatileStatusType::Charging(1)));
-        assert_ne!(bound, Some(VolatileStatusType::Recharging(1)));
-        assert_eq!(6.25, bound.as_ref().unwrap().status_damage(&100.0));
 
         // CONFUSION TEST
-        match confusion {
-            Some(VolatileStatusType::Confusion(confusion_count)) => {
-                assert_eq!(confusion, Some(VolatileStatusType::Confusion(1)));
-                assert_eq!(confusion_count, 1);
-                confusion = Some(VolatileStatusType::Confusion(2));
-                assert_eq!(confusion, Some(VolatileStatusType::Confusion(2)));
-            }
-            _ => panic!("Confusion test failed"),
-        }
-        assert_ne!(confusion, bound);
-        assert_ne!(confusion, flinch);
-        assert_ne!(confusion, seeded);
-        assert_ne!(confusion, rampage);
-        assert_ne!(confusion, charging);
-        assert_ne!(confusion, recharging);
-        assert_ne!(confusion, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(confusion, Some(VolatileStatusType::Flinch));
-        assert_ne!(confusion, Some(VolatileStatusType::Seeded));
-        assert_ne!(confusion, Some(VolatileStatusType::Rampage(3)));
-        assert_ne!(confusion, Some(VolatileStatusType::Charging(1)));
-        assert_ne!(confusion, Some(VolatileStatusType::Recharging(1)));
-        // TODO: Write assert for confusion damage given hp, attack, and defense of confused pokemon
 
         // FLINCH TEST
-        match flinch {
-            Some(VolatileStatusType::Flinch) => {
-                assert_eq!(flinch, Some(VolatileStatusType::Flinch));
-            }
-            _ => panic!("Flinch test failed"),
-        }
-        assert_ne!(flinch, bound);
-        assert_ne!(flinch, confusion);
-        assert_ne!(flinch, seeded);
-        assert_ne!(flinch, rampage);
-        assert_ne!(flinch, charging);
-        assert_ne!(flinch, recharging);
-        assert_ne!(flinch, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(flinch, Some(VolatileStatusType::Confusion(1)));
-        assert_ne!(flinch, Some(VolatileStatusType::Seeded));
-        assert_ne!(flinch, Some(VolatileStatusType::Rampage(3)));
-        assert_ne!(flinch, Some(VolatileStatusType::Charging(1)));
-        assert_ne!(flinch, Some(VolatileStatusType::Recharging(1)));
-        assert_eq!(0.0, flinch.as_ref().unwrap().status_damage(&100.0));
 
         // SEEDED TEST
-        match seeded {
-            Some(VolatileStatusType::Seeded) => {
-                assert_eq!(seeded, Some(VolatileStatusType::Seeded));
-            }
-            _ => panic!("Seeded test failed"),
-        }
-        assert_ne!(seeded, bound);
-        assert_ne!(seeded, confusion);
-        assert_ne!(seeded, flinch);
-        assert_ne!(seeded, rampage);
-        assert_ne!(seeded, charging);
-        assert_ne!(seeded, recharging);
-        assert_ne!(seeded, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(seeded, Some(VolatileStatusType::Confusion(1)));
-        assert_ne!(seeded, Some(VolatileStatusType::Flinch));
-        assert_ne!(seeded, Some(VolatileStatusType::Rampage(3)));
-        assert_ne!(seeded, Some(VolatileStatusType::Charging(1)));
-        assert_ne!(seeded, Some(VolatileStatusType::Recharging(1)));
-        assert_eq!(12.5, seeded.as_ref().unwrap().status_damage(&100.0));
 
         // RAMPAGE TEST
-        match rampage {
-            Some(VolatileStatusType::Rampage(rampage_count)) => {
-                assert_eq!(rampage, Some(VolatileStatusType::Rampage(1)));
-                assert_eq!(rampage_count, 1);
-                rampage = Some(VolatileStatusType::Rampage(2));
-                assert_eq!(rampage, Some(VolatileStatusType::Rampage(2)));
-            }
-            _ => panic!("Rampage test failed"),
-        }
-        assert_ne!(rampage, bound);
-        assert_ne!(rampage, flinch);
-        assert_ne!(rampage, seeded);
-        assert_ne!(rampage, confusion);
-        assert_ne!(rampage, charging);
-        assert_ne!(rampage, recharging);
-        assert_ne!(rampage, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(rampage, Some(VolatileStatusType::Flinch));
-        assert_ne!(rampage, Some(VolatileStatusType::Seeded));
-        assert_ne!(rampage, Some(VolatileStatusType::Confusion(3)));
-        assert_ne!(rampage, Some(VolatileStatusType::Charging(1)));
-        assert_ne!(rampage, Some(VolatileStatusType::Recharging(1)));
-        assert_eq!(0.0, rampage.as_ref().unwrap().status_damage(&100.0));
 
         // CHARGING TEST
-        match charging {
-            Some(VolatileStatusType::Charging(charge_count)) => {
-                assert_eq!(charging, Some(VolatileStatusType::Charging(1)));
-                assert_eq!(charge_count, 1);
-                charging = Some(VolatileStatusType::Charging(2));
-                assert_eq!(charging, Some(VolatileStatusType::Charging(2)));
-            }
-            _ => panic!("Charging test failed"),
-        }
-        assert_ne!(charging, bound);
-        assert_ne!(charging, flinch);
-        assert_ne!(charging, seeded);
-        assert_ne!(charging, confusion);
-        assert_ne!(charging, rampage);
-        assert_ne!(charging, recharging);
-        assert_ne!(charging, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(charging, Some(VolatileStatusType::Flinch));
-        assert_ne!(charging, Some(VolatileStatusType::Seeded));
-        assert_ne!(charging, Some(VolatileStatusType::Confusion(3)));
-        assert_ne!(charging, Some(VolatileStatusType::Rampage(1)));
-        assert_ne!(charging, Some(VolatileStatusType::Recharging(1)));
-        assert_eq!(0.0, charging.as_ref().unwrap().status_damage(&100.0));
 
         // RECHARGING TEST
-        match recharging {
-            Some(VolatileStatusType::Recharging(recharge_count)) => {
-                assert_eq!(recharging, Some(VolatileStatusType::Recharging(1)));
-                assert_eq!(recharge_count, 1);
-                recharging = Some(VolatileStatusType::Recharging(2));
-                assert_eq!(recharging, Some(VolatileStatusType::Recharging(2)));
-            }
-            _ => panic!("Recharging test failed"),
-        }
-        assert_ne!(recharging, bound);
-        assert_ne!(recharging, flinch);
-        assert_ne!(recharging, seeded);
-        assert_ne!(recharging, confusion);
-        assert_ne!(recharging, rampage);
-        assert_ne!(recharging, charging);
-        assert_ne!(recharging, Some(VolatileStatusType::Bound(1)));
-        assert_ne!(recharging, Some(VolatileStatusType::Flinch));
-        assert_ne!(recharging, Some(VolatileStatusType::Seeded));
-        assert_ne!(recharging, Some(VolatileStatusType::Confusion(3)));
-        assert_ne!(recharging, Some(VolatileStatusType::Rampage(1)));
-        assert_ne!(recharging, Some(VolatileStatusType::Charging(1)));
-        assert_eq!(0.0, recharging.as_ref().unwrap().status_damage(&100.0));
     }
 }


### PR DESCRIPTION
Update status to be a struct that's a part of the Pokemon. This radically simplifies the enums and leads to a cleaner implementation.